### PR TITLE
Fix image printing error in plugin

### DIFF
--- a/android/src/main/java/com/haidang/xprinter/CapacitorXprinter.java
+++ b/android/src/main/java/com/haidang/xprinter/CapacitorXprinter.java
@@ -437,7 +437,7 @@ public class CapacitorXprinter {
                     case "right": alignment = 2; break;
                     default: alignment = 0; break;
                 }
-                ((PosPrinterWrapper) currentPrinter).printImageFromPath(imagePath, width, alignment);
+                ((PosPrinterWrapper) currentPrinter).printImageFromPath(imagePath, width, alignment, context);
             } else if (currentPrinter instanceof CpclPrinterWrapper) {
                 int x = options.has("x") ? options.getInteger("x") : 0;
                 int y = options.has("y") ? options.getInteger("y") : 0;


### PR DESCRIPTION
Pre-decode image paths to Bitmap before printing to fix `NullPointerException` with non-file URIs.

The underlying SDK's `printBitmap(String path, ...)` method failed to decode image paths containing schemes (e.g., `file://`, `content://`, `data:`), leading to a `NullPointerException` when attempting to use the resulting null Bitmap. This change pre-processes the image path into a `Bitmap` before passing it to the SDK, ensuring robust handling of various URI types.